### PR TITLE
Fix LaTeX Error: Too deeply nested

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ pandoc OSCP-exam-report-template_whoisflynn_v3.2.md \
 --toc-depth 6 \
 --number-sections \
 --top-level-division=chapter \
---highlight-style breezedark
+--highlight-style breezedark \
+-H deeplists.tex
 ```
 
 You can change the code syntax highlight theme with [`--highlight-style`](https://pandoc.org/MANUAL.html#option--highlight-style).

--- a/deeplists.tex
+++ b/deeplists.tex
@@ -1,0 +1,24 @@
+   \usepackage{enumitem}
+   \setlistdepth{9}
+
+   \setlist[itemize,1]{label=$\bullet$}
+   \setlist[itemize,2]{label=$\bullet$}
+   \setlist[itemize,3]{label=$\bullet$}
+   \setlist[itemize,4]{label=$\bullet$}
+   \setlist[itemize,5]{label=$\bullet$}
+   \setlist[itemize,6]{label=$\bullet$}
+   \setlist[itemize,7]{label=$\bullet$}
+   \setlist[itemize,8]{label=$\bullet$}
+   \setlist[itemize,9]{label=$\bullet$}
+   \renewlist{itemize}{itemize}{9}
+
+   \setlist[enumerate,1]{label=$\arabic*.$}
+   \setlist[enumerate,2]{label=$\alph*.$}
+   \setlist[enumerate,3]{label=$\roman*.$}
+   \setlist[enumerate,4]{label=$\arabic*.$}
+   \setlist[enumerate,5]{label=$\alpha*$}
+   \setlist[enumerate,6]{label=$\roman*.$}
+   \setlist[enumerate,7]{label=$\arabic*.$}
+   \setlist[enumerate,8]{label=$\alph*.$}
+   \setlist[enumerate,9]{label=$\roman*.$}
+   \renewlist{enumerate}{enumerate}{9}


### PR DESCRIPTION
When there are too many indentation levels (lists more than 6 levels deep)
pandoc fails to generate a pdf and exit with the above error, this is intended
to be a fix for that problem, for more details see the issue below:
https://github.com/jgm/pandoc/issues/2922