### PR TITLE
support code block wrap to fix #21

### DIFF
--- a/generate.rb
+++ b/generate.rb
@@ -94,6 +94,7 @@ pdf = "output/#{exam}-#{osid}-Exam-Report.pdf"
   --template eisvogel \
   --table-of-contents \
   --toc-depth 6 \
+  --listings -H wrap \
   --number-sections \
   --top-level-division=chapter \
   --highlight-style #{style}

--- a/wrap
+++ b/wrap
@@ -1,0 +1,2 @@
+\usepackage{fvextra}
+\DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,breakanywhere,commandchars=\\\{\}}


### PR DESCRIPTION
reference https://tex.stackexchange.com/questions/179926/pandoc-markdown-to-pdf-without-cutting-off-code-block-lines-that-are-too-long