### PR TITLE
Added information about disabling image floating

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -109,4 +109,4 @@ This is a [known and open issue with pandoc](https://github.com/jgm/pandoc/issue
 }
 ```
 
-The add `-H path/to/disable_float.tex` to your `pandoc` command when rendering the report. This will force `pandoc` to render the images in the order that they appear in the original Markdown file while also preserving their captions. [Source](http://stackoverflow.com/a/33801326/1407737). 
+Then add `-H path/to/disable_float.tex` to your `pandoc` command when rendering the report. This will force `pandoc` to render the images in the order that they appear in the original Markdown file while also preserving their captions. [Source](http://stackoverflow.com/a/33801326/1407737). 

--- a/FAQ.md
+++ b/FAQ.md
@@ -93,3 +93,20 @@ Then testing all syntax highlight styles for all languages:
 ```zsh
 $ for s in $(pandoc --list-highlight-styles); do pandoc --template eisvogel --highlight-style $s -o highlight-$s.pdf highlight-languages.md; done;
 ```
+
+## Why are my images formatted in the wrong locations?
+
+This is a [known and open issue with pandoc](https://github.com/jgm/pandoc/issues/845). A simple hack is to create a file called `disable_float.tex` with the following content:
+
+```latex
+\usepackage{float}
+\let\origfigure\figure
+\let\endorigfigure\endfigure
+\renewenvironment{figure}[1][2] {
+    \expandafter\origfigure\expandafter[H]
+} {
+    \endorigfigure
+}
+```
+
+The add `-H path/to/disable_float.tex` to your `pandoc` command when rendering the report. This will force `pandoc` to render the images in the order that they appear in the original Markdown file while also preserving their captions. [Source](http://stackoverflow.com/a/33801326/1407737). 


### PR DESCRIPTION
Hello! Great repository! I just used it to write my OSEP report. 

One issue that I lost a bit of time debugging was rendering images in the proper locations without losing their captions. E.g., the following markdown:

```
## Local Privilege Escalation

jwhenry28 obtained local privilege escalation with Meterpreter's `getsystem` command:

![Elevating local privileges](img/privEsc.png)

This resulted in a SYSTEM level Meterpreter session.
```

might render with the image at the very bottom or on an earlier page. This PR adds a quick fix to the `FAQ.md` file to resolve this issue. 