### PR TITLE
Fix Arch dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Examples:
 
 Examples for common distros:
 
-- ArchLinux: `pacman -S texlive-most pandoc p7zip`
+- ArchLinux: `pacman -S ruby p7zip haskell-pandoc texlive-core texlive-fontsextra texlive-fontsrecommended texlive-latexextra`
 - openSUSE: `zypper in texlive-scheme-medium pandoc p7zip-full`
 - Ubuntu: `apt install texlive-latex-recommended texlive-fonts-extra texlive-latex-extra pandoc p7zip-full`
 


### PR DESCRIPTION
`texlive-most` is not available in Arch repository. Replaced with working dependencies. Fixed in https://github.com/BlackArch/blackarch/pull/4131 too.