### PR TITLE
Update osert.rb

### DIFF
--- a/osert.rb
+++ b/osert.rb
@@ -275,7 +275,7 @@ begin
     end
 
     if options[:osid]
-      osid = options[:osid]
+      osid = "OS-" + options[:osid]
     else
       puts '[+] Enter your OS ID:'
       print '> OS-'


### PR DESCRIPTION
If the user provides the osid as parameter, then 'The OS-' prefix will not be set. https://github.com/noraj/OSCP-Exam-Report-Template-Markdown/blob/2e245f8ff07664d08bfad6a493323776bfa05431/osert.rb#L278