### PR TITLE
Fix issues for file path with spaces

### DIFF
--- a/osert.rb
+++ b/osert.rb
@@ -329,7 +329,7 @@ begin
     # Generating archive
     puts '[+] Generating archive...'
     archive = "#{output}/#{exam}-#{osid}-Exam-Report.7z"
-    `7z a #{archive.shellescape} #{File.expand_path(pdf.shellescape)}`
+    `7z a "#{archive.shellescape}" "#{File.expand_path(pdf.shellescape)}"`
 
     # Optional lab report
     puts_prompt '[+] Do you want to add an external lab report? [Y/n]'


### PR DESCRIPTION
In the current implementation, if a file path contains space, 7z archiving does not work and the script errors out. Using double quote should fix that. 

**Before:** 

![image](https://github.com/user-attachments/assets/31e8492c-7b06-443b-be47-e80c5247bf1e)



**After:**

![image](https://github.com/user-attachments/assets/2672ed19-6cea-432a-a199-a4898ef75526)
